### PR TITLE
Improve template API; Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,116 +1,143 @@
-# LLM Ruleset Manager
+# AI Ruleset Manager
 
-A template repository for managing reusable Markdown "rules" that can be composed into comprehensive LLM instruction documentation. Perfect for teams that want to maintain consistent, modular AI prompts and instructions.
+A template repository for managing reusable rule fragments (plain `*.md` files) that can be composed into comprehensive LLM instruction documentation. Perfect for individuals who want to manage their LLM instructions with `git` and compose specific rulesets from personal rule databases.
+
+## Problem
+Often projects have their own `*.md` rule/context files that provide LLMs with context about the project (architecture/design/styling/etc). This leaves no place for user-defined instructions that don't belong in the project (user-specific workflows/preferences/etc).
+
+_A way_ out of this problem is to have a git-ignored `*.local.md` file that contains such user preferences. Keeping such ignored files outside of version control can get messy, especially if user wishes to carry their LLM instructions across multiple machines.
+
+## Solution
+Split LLM rule/context file into individual `*.md` rule files and build specific context file for specific project/LLM tool. Here's an example of what a repository could look like with this template:
+```
+my-ai-ruleset/
+├── scripts/
+│   ├── ai-rules            # Main CLI tool, copied from the template
+│   └── test                # Test runner, copied from the template
+├── rules/
+│   ├── ruby                # Database of specific user rules for Ruby
+│   ├── rails               # Database of specific user rules for Rails
+│   └── my_rails_project    # Database of specific user project rules
+├── build/
+│   └── my_rails_project.md # Stores compiled artifacts (in case of using symlinks)
+└── test/                   # Comprehensive test suite
+    ├── fixtures/           # Test data
+    └── *.sh                # Test scripts, automatically invoked by scripts/test
+```
 
 ## 🚀 Quick Start
 
 1. **Use this template**: Click "Use this template" on GitHub to create your own repository
-2. **Install the CLI** (optional):
+2. **Clone your repository**: Clone your repository to your local machine
+2. **Install the CLI**:
    ```bash
-   ./scripts/llm-rules install
+   ./scripts/ai-rules install # Creates `ai-rules` CLI command at your PATH
+   ```
+   
+   Or as custom binary command:
+   ```bash
+   ./scripts/ai-rules install --bin-name <binary command name of your choice>
    ```
 3. **Create your first rule database**:
    ```bash
-   ./scripts/llm-rules new --database myproject
+   ai-rules new --database rails
    ```
-4. **Add some rules** to `rules/myproject/rules/`:
+4. **Add rules** to `rules/<database-name>/rules/`, e.g. specific rules for Rails projects:
    ```bash
-   echo "## Code Quality\nAlways write clean, readable code." > rules/myproject/rules/code-quality.md
-   echo "## Testing\nWrite comprehensive tests." > rules/myproject/rules/testing.md
+   echo "Classes should always be defined as one-liners, e.g. `MyModule::AnotherModule::MyClass`." > rules/ruby/rules/class-definitions.md
+   echo "# Callbacks\nNever use callbacks on models." > rules/rails/rules/models.md
+   echo "# Testing\nAlways start writing tests with a basic outline and let me review it." > rules/rails/rules/testing.md
+   echo "# Testing controllers\nNever do ..." > rules/rails/rules/testing-controllers.md
    ```
-5. **Create a manifest** in `rules/myproject/manifest`:
+5. **Create a manifest** in `rules/<database-name>/manifest`:
    ```
-   # My Project Rules
-   | code-quality
-   | testing
+   | ruby/class-definitions
+   | rails/models
+   | rails/testing
+   || rails/testing-controllers
    ```
-6. **Build your documentation**:
+   Every rule fragment creates properly indented entry in the resulting `*.local.md` file.
+6. **Compile your ruleset**:
    ```bash
-   ./scripts/llm-rules build --manifest rules/myproject/manifest
+   ai-rules build --manifest rules/<database-name>/manifest --out ~/my_project/CLAUDE.local.md
    ```
-
-Your compiled documentation will be in `build/myproject.md`!
-
-## 📋 Features
-
-- **🧩 Modular Rules**: Break complex instructions into reusable components
-- **📚 Multiple Databases**: Organize rules by project, team, or domain
-- **🌳 Hierarchical Structure**: Support for nested rule organization (up to 6 levels)
-- **📝 Automatic Titles**: Auto-generated rule titles and proper heading levels
-- **✅ Validation**: Built-in validation to catch errors before building
-- **🔧 POSIX Compatible**: Works on any Unix-like system
-- **🧪 Comprehensive Tests**: 17 test cases covering functionality and edge cases
-
-## 📁 Project Structure
-
-```
-llm-ruleset-manager/
-├── scripts/
-│   ├── llm-rules          # Main CLI tool
-│   └── test              # Test runner
-├── rules/
-│   └── README.md         # Template for rule databases
-├── build/
-│   └── .example.md       # Example output
-└── test/                 # Comprehensive test suite
-    ├── fixtures/         # Test data
-    └── *.sh             # Test scripts
-```
 
 ## 🛠️ CLI Commands
 
-### Build Documentation
+### Install CLI
 ```bash
-./scripts/llm-rules build --manifest <path> [--out <file>]
+./scripts/ai-rules install [--prefix <path>]
 ```
-Compiles rules from a manifest into a single markdown file.
-
-**Examples:**
-```bash
-# Build with default output location
-./scripts/llm-rules build --manifest rules/myproject/manifest
-
-# Build with custom output
-./scripts/llm-rules build --manifest rules/myproject/manifest --out custom-docs.md
-```
+Installs the CLI tool to your system.
 
 ### Create New Database
 ```bash
-./scripts/llm-rules new --database <name>
+ai-rules new --database <name>
 ```
 Creates a new rule database with proper directory structure.
 
 **Example:**
 ```bash
-./scripts/llm-rules new --database frontend-rules
+ai-rules new --database react
 ```
 
 ### Validate Manifest
 ```bash
-./scripts/llm-rules validate --manifest <path>
+ai-rules validate --manifest <path>
 ```
-Validates manifest syntax and checks that all referenced rules exist.
+Validates manifest syntax and checks that all referenced rules exist. Validation is also run before `ai-rules build`.
 
 **Example:**
 ```bash
-./scripts/llm-rules validate --manifest rules/myproject/manifest
+ai-rules validate --manifest rules/myproject/manifest
 ```
 
-### Install CLI
+### Compile ruleset
 ```bash
-./scripts/llm-rules install [--prefix <path>]
+ai-rules build --manifest <path> [--out <file>]
 ```
-Installs the CLI tool to your system.
+Compiles rules from a manifest into a single markdown file at destination, or in `build/` directory.
+
+**Examples:**
+```bash
+# Build with default output location
+ai-rules build --manifest rules/myproject/manifest
+
+# Build with custom output
+ai-rules build --manifest rules/myproject/manifest --out path/to/myproject/ai-context.md
+```
 
 ### Deploy Documentation
 ```bash
-./scripts/llm-rules deploy --manifest <path> --out <file>
+ai-rules build-link --manifest <path> --out <symlink path>
 ```
 Builds documentation and creates a symlink for easy access.
 
+## 🪢 Dependencies
+
+**Runtime dependencies**:
+- POSIX-compliant shell (`/bin/sh`)
+- `cat`
+- `sed`
+- `cut`
+- `wc`
+- `basename`
+- `dirname`
+- `pwd`
+- `cd`
+- `mkdir`
+- `ln`
+- `mv`
+- `rm`
+- `read`
+
+**Development dependencies**:
+- `diff`
+- `grep`
+
 ## 📋 Manifest Format
 
-Manifests use a pipe-based hierarchical format:
+Manifests use simple text-based hierarchical format:
 
 ```
 # Comments start with #
@@ -127,181 +154,26 @@ Manifests use a pipe-based hierarchical format:
 - Up to 6 levels supported
 - Each level must increase by exactly 1 (no skipping levels)
 
+### Rationale
+
+**Why not YAML/JSON/TOML?:**
+- There's no easy way to parse any of those formats (that I know of) without external dependencies that are not written in POSIX shell script
+
+**Why `|`?:**
+- Because if you squint, it makes the hierarchy look like a tree
+- For easy parsing
+
 ## 📝 Writing Rules
 
-Rules are standard Markdown files stored in `rules/<database>/rules/`:
+- Rules are standard Markdown files stored in `rules/<database>/rules/*.md`
+- Use any heading levels you want - they'll be automatically normalized based on hierarchy
+- Each rule file becomes a titled section in the output (e.g. `# Rule: my_rule`)
+- Try to keep rules small and focused for easy composition & re-use in the manifest
 
-**rules/myproject/rules/code-style.md:**
-```markdown
-## Consistent Formatting
-
-Use consistent code formatting throughout the project.
-
-### Naming Conventions
-- Use camelCase for variables
-- Use PascalCase for classes
-
-### Indentation
-Use 2 spaces for indentation.
-```
-
-**Key Points:**
-- Use any heading levels you want - they'll be automatically normalized
-- Support for code blocks, lists, links, and all Markdown features
-- Each rule file becomes a titled section in the output
-
-## 🏗️ Example Workflow
-
-### 1. Create a New Project Database
-```bash
-./scripts/llm-rules new --database react-guidelines
-```
-
-### 2. Add Rules
-```bash
-# Component rules
-cat > rules/react-guidelines/rules/component-structure.md <<EOF
-## Component Structure
-
-Every React component should follow this structure:
-- Props interface at the top
-- Component function with proper typing
-- Export at the bottom
-EOF
-
-# State management rules
-cat > rules/react-guidelines/rules/state-management.md <<EOF
-## State Management
-
-Use React hooks for local state:
-- useState for simple state
-- useReducer for complex state logic
-EOF
-```
-
-### 3. Create Manifest
-```bash
-cat > rules/react-guidelines/manifest <<EOF
-# React Development Guidelines
-| component-structure
-| state-management
-EOF
-```
-
-### 4. Build and Validate
-```bash
-# Validate first
-./scripts/llm-rules validate --manifest rules/react-guidelines/manifest
-
-# Build documentation
-./scripts/llm-rules build --manifest rules/react-guidelines/manifest
-```
-
-### 5. Use Your Documentation
-The compiled documentation in `build/react-guidelines.md` will look like:
-```markdown
-# Rule: component-structure
-
-## Component Structure
-
-Every React component should follow this structure:
-- Props interface at the top
-- Component function with proper typing
-- Export at the bottom
-
-# Rule: state-management
-
-## State Management
-
-Use React hooks for local state:
-- useState for simple state
-- useReducer for complex state logic
-```
-
-## 🌳 Hierarchical Example
-
-**Manifest:**
-```
-# Complex Project Structure
-| introduction
-| architecture
-|| frontend
-||| components
-||| styling
-|| backend
-||| api-design
-||| database
-| conclusion
-```
-
-**Output Structure:**
-```markdown
-# Rule: introduction
-## Introduction
-...
-
-# Rule: architecture
-## Architecture
-...
-
-## Rule: frontend
-### Frontend
-...
-
-### Rule: components
-#### Components
-...
-
-### Rule: styling
-#### Styling
-...
-
-## Rule: backend
-### Backend
-...
-
-# Rule: conclusion
-## Conclusion
-...
-```
-
-## 🧪 Testing
-
-Run the comprehensive test suite:
-```bash
-# Run all tests
-./scripts/test
-
-# Run specific tests
-./scripts/test build-01-basic.sh validate-01-basic.sh
-
-# Run tests by pattern
-./scripts/test build-*
-```
-
-**Test Coverage:**
-- ✅ Build functionality (basic, nested, error conditions)
-- ✅ Validation (success and error cases)
-- ✅ New database creation
-- ✅ Edge cases (missing files, invalid nesting, EOF handling)
-
-## 🔧 Development
-
-**Requirements:**
-- POSIX-compliant shell
-- Standard Unix utilities (`grep`, `sed`, `awk`)
-
-**Environment Variables:**
-- `LLM_RULES_DIR`: Override rules directory (useful for testing)
-
-## 📄 Use Cases
-
-Perfect for:
-- **AI/LLM Prompt Engineering**: Modular, reusable prompt components
-- **Team Coding Standards**: Shared development guidelines
-- **Documentation Templates**: Consistent documentation across projects
-- **Policy Management**: Modular business rules and policies
-- **Training Materials**: Structured learning content
+## 🔤 Glossary
+- **Rule/Fragment**: A markdown file with instructions for LLMs on highly specific topic
+- **Database**: A folder containing `rules/*.md` and `manifest` file
+- **Manifest**: A file that describes the hierarchy of rules make it into the final compiled output file for LLMs to consume
 
 ## 🤝 Contributing
 
@@ -311,10 +183,21 @@ Perfect for:
 4. Ensure all tests pass: `./scripts/test`
 5. Submit a pull request
 
-## 📧 Support
+### 🧪 Testing
+When it comes to development of the template itself, here's the files contributor should care about:
+```
+ai-ruleset-manager/
+├── scripts/
+│   ├── ai-rules            # Main CLI tool, runned by automated tests
+│   └── test                # Test runner, runs test/*.sh test scripts
+└── test/                   # Comprehensive test suite
+    ├── tmp/                # Place for test build artifacts
+    ├── fixtures/           # Test data
+    └── *.sh                # Test scripts, automatically invoked by scripts/test
+```
+To test the project, run `./scripts/test`. Run specific test file with `./scripts/test build-01-basic`.
 
-This is a template repository - customize it for your needs! The CLI tool is designed to be portable and easily modified.
-
----
-
-**Happy rule management!** 🎉
+## 🗺️ Roadmap
+- Shell completions
+- More comprehensive tests with combination of features (comments + deep nesting + rules from various databases)
+- Better folder structure semantics

--- a/scripts/ai-rules
+++ b/scripts/ai-rules
@@ -266,11 +266,13 @@ process_rule() {
             ;;
     esac
 
-    # Handle cross-database includes (e.g., other-db/rule.md)
+    # Handle cross-database includes (e.g., other-db/rule)
     case "$rule_path" in
         */*)
-            # Cross-database reference
-            full_path="$RULES_DIR/$rule_path"
+            # Cross-database reference: database/rule -> RULES_DIR/database/rules/rule.md
+            db_name="${rule_path%%/*}"
+            rule_name="${rule_path#*/}"
+            full_path="$RULES_DIR/$db_name/rules/$rule_name"
             ;;
         *)
             # Local to current database
@@ -292,13 +294,25 @@ process_rule() {
         printf '#'
         i=$((i + 1))
     done
-    printf ' %s\n\n' "$rule_title"
+    printf ' %s\n' "$rule_title"
 
     # Normalize and output the rule content with target level + 1 (nested under title)
+    # Create temporary file with normalized content
     content_level=$((target_level + 1))
-    normalize_headings "$full_path" "$content_level"
+    temp_content=$(mktemp)
+    normalize_headings "$full_path" "$content_level" > "$temp_content"
 
-    # Add newline between rules
+    # Trim leading blank lines
+    sed -i '/./,$!d' "$temp_content"
+
+    # Trim trailing blank lines
+    sed -i -e :a -e '/^\s*$/{$d;N;ba' -e '}' "$temp_content"
+
+    # Output the trimmed content
+    cat "$temp_content"
+    rm -f "$temp_content"
+
+    # Add single newline between rules
     printf '\n'
 }
 
@@ -386,14 +400,10 @@ validate_manifest() {
                     level=$(echo "$parsed" | cut -d' ' -f1)
                     rule_name=$(echo "$parsed" | cut -d' ' -f2-)
 
-                    # Validate nesting (can't jump levels)
+                    # Validate nesting (can't jump levels) - auto-correct for validation
                     if [ $level -gt $((prev_level + 1)) ]; then
-                        echo "Error: Invalid nesting in manifest. Level $level follows level $prev_level." >&2
-                        echo "Line: $line" >&2
-                        echo "Referenced in manifest: $manifest_path" >&2
-                        missing_rules=$((missing_rules + 1))
-                        total_rules=$((total_rules + 1))
-                        continue
+                        corrected_level=$((prev_level + 1))
+                        level=$corrected_level
                     fi
 
                     total_rules=$((total_rules + 1))
@@ -412,8 +422,12 @@ validate_manifest() {
                     # Check if rule file exists
                     case "$rule_name" in
                         */*)
-                            # Cross-database reference
-                            rule_path="$RULES_DIR/$rule_name"
+                            # Cross-database reference: database/rule -> RULES_DIR/database/rules/rule.md
+                            db_name="${rule_name%%/*}"
+                            rule_file="${rule_name#*/}"
+                            # Remove .md if present, will be re-added
+                            rule_file="${rule_file%.md}.md"
+                            rule_path="$RULES_DIR/$db_name/rules/$rule_file"
                             ;;
                         *)
                             # Local rule
@@ -515,18 +529,24 @@ cmd_build() {
     manifest_dir=$(dirname "$manifest")
 
     # Determine output file if not specified
+    local using_default_build_dir=false
     if [ -z "$output" ]; then
         # Extract database name from manifest path
         database=$(basename "$manifest_dir")
         output="build/${database}.md"
+        using_default_build_dir=true
     fi
 
-    # Check if output directory exists
+    # Check if output directory exists, auto-create if using default build/ directory
     output_dir=$(dirname "$output")
     if [ ! -d "$output_dir" ]; then
-        echo "Error: Output directory does not exist: $output_dir" >&2
-        echo "Create it first with: mkdir -p $output_dir" >&2
-        exit 1
+        if [ "$using_default_build_dir" = true ]; then
+            mkdir -p "$output_dir"
+        else
+            echo "Error: Output directory does not exist: $output_dir" >&2
+            echo "Create it first with: mkdir -p $output_dir" >&2
+            exit 1
+        fi
     fi
 
     # Build to a temporary file first, then move to output
@@ -556,13 +576,14 @@ cmd_build() {
 
                     # Validate nesting - can only increase by 1, but can decrease to any level
                     if [ $level -gt $((prev_level + 1)) ]; then
-                        echo "Error: Invalid nesting in manifest. Level $level follows level $prev_level." >&2
+                        corrected_level=$((prev_level + 1))
+                        echo "Warning: Invalid nesting in manifest. Level $level follows level $prev_level." >&2
                         echo "Line: $line" >&2
-                        rm -f "$tmp_output"
-                        exit 1
+                        echo "Auto-correcting to level $corrected_level" >&2
+                        level=$corrected_level
                     fi
 
-                    # Process the rule with the specified level
+                    # Process the rule with the corrected level
                     process_rule "$rule_name" "$manifest_dir" "$level" >> "$tmp_output"
 
                     # Update prev_level for next iteration
@@ -580,8 +601,9 @@ cmd_build() {
         esac
     done < "$manifest"
 
-    # Move temporary file to final output
-    mv "$tmp_output" "$output"
+    # Trim trailing whitespace and move to final output
+    sed -e :a -e '/^\s*$/{$d;N;ba' -e '}' "$tmp_output" > "$output"
+    rm -f "$tmp_output"
 
     echo "Successfully built $output from $manifest"
 }
@@ -821,7 +843,6 @@ cmd_new() {
 
     # Create manifest template
     cat > "$database_dir/manifest" <<EOF
-# $database Database Manifest
 # Add your rule files below using the pipe format
 
 | basic
@@ -925,13 +946,12 @@ cmd_validate() {
                     level=$(echo "$parsed" | cut -d' ' -f1)
                     rule_name=$(echo "$parsed" | cut -d' ' -f2-)
 
-                    # Validate nesting (can't jump levels)
+                    # Validate nesting (can't jump levels) - show warning but auto-correct
                     if [ $level -gt $((prev_level + 1)) ]; then
-                        echo "✗ Invalid nesting: level $level follows level $prev_level"
+                        corrected_level=$((prev_level + 1))
+                        echo "⚠ Nesting warning: level $level follows level $prev_level (will auto-correct to $corrected_level)"
                         echo "   Line: $line"
-                        missing_rules=$((missing_rules + 1))
-                        total_rules=$((total_rules + 1))
-                        continue
+                        level=$corrected_level
                     fi
 
                     total_rules=$((total_rules + 1))
@@ -950,8 +970,12 @@ cmd_validate() {
                     # Check if rule file exists
                     case "$rule_name" in
                         */*)
-                            # Cross-database reference
-                            rule_path="$RULES_DIR/$rule_name"
+                            # Cross-database reference: database/rule -> RULES_DIR/database/rules/rule.md
+                            db_name="${rule_name%%/*}"
+                            rule_file="${rule_name#*/}"
+                            # Remove .md if present, will be re-added
+                            rule_file="${rule_file%.md}.md"
+                            rule_path="$RULES_DIR/$db_name/rules/$rule_file"
                             ;;
                         *)
                             # Local rule

--- a/scripts/ai-rules
+++ b/scripts/ai-rules
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-# LLM Ruleset Manager - Template Repository CLI
+# AI Ruleset Manager - Template Repository CLI
 # POSIX-compliant script for building rule documentation from manifests
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -12,20 +12,20 @@ VERSION="1.0.0"
 # Print usage
 usage() {
     cat <<EOF
-llm-rules - Build and manage LLM instruction rulesets
+ai-rules - Build and manage AI instruction rulesets
 
 Usage:
-    llm-rules <command> [options]
+    ai-rules <command> [options]
 
 Commands:
     build       Build documentation from a manifest
-    install     Install llm-rules to your system
-    deploy      Build and symlink output to a location
-    validate    Validate a database manifest (coming soon)
-    new         Create a new database (coming soon)
+    install     Install ai-rules to your system
+    build-link  Build and symlink output to a location
+    validate    Validate a database manifest
+    new         Create a new database
     help        Show this help message
 
-Run 'llm-rules <command> --help' for more information on a command.
+Run 'ai-rules <command> --help' for more information on a command.
 
 Version: $VERSION
 EOF
@@ -34,7 +34,7 @@ EOF
 # Build command usage
 usage_build() {
     cat <<EOF
-Usage: llm-rules build --manifest <path> [--out <file>]
+Usage: ai-rules build --manifest <path> [--out <file>]
 
 Build documentation from a manifest file.
 
@@ -43,47 +43,49 @@ Options:
     --out <file>        Output file path (default: build/<database>.md)
 
 Example:
-    llm-rules build --manifest rules/myproject/manifest.ini
-    llm-rules build --manifest rules/myproject/manifest.ini --out docs.md
+    ai-rules build --manifest rules/myproject/manifest
+    ai-rules build --manifest rules/myproject/manifest --out docs.md
 EOF
 }
 
 # Install command usage
 usage_install() {
     cat <<EOF
-Usage: llm-rules install [--prefix <path>]
+Usage: ai-rules install [--prefix <path>] [--bin-name <name>]
 
-Install llm-rules to your system.
+Install ai-rules to your system.
 
 Options:
     --prefix <path>     Installation directory (will prompt if not provided)
+    --bin-name <name>   Custom binary name (default: ai-rules)
 
 Example:
-    llm-rules install --prefix ~/bin
-    llm-rules install --prefix /usr/local/bin
+    ai-rules install --prefix ~/bin
+    ai-rules install --prefix /usr/local/bin
+    ai-rules install --bin-name my-ai-tool
 EOF
 }
 
-# Deploy command usage
-usage_deploy() {
+# Build-link command usage
+usage_build_link() {
     cat <<EOF
-Usage: llm-rules deploy --manifest <path> --out <file>
+Usage: ai-rules build-link --manifest <path> --out <file>
 
 Build documentation and create a symlink at the specified location.
 
 Options:
-    --manifest <path>   Path to manifest.ini file (required)
+    --manifest <path>   Path to manifest file (required)
     --out <file>        Symlink destination path (required)
 
 Example:
-    llm-rules deploy --manifest rules/myproject/manifest.ini --out ~/docs/project.md
+    ai-rules build-link --manifest rules/myproject/manifest --out ~/docs/project.md
 EOF
 }
 
 # New command usage
 usage_new() {
     cat <<EOF
-Usage: llm-rules new --database <name>
+Usage: ai-rules new --database <name>
 
 Create a new database with template structure.
 
@@ -91,15 +93,15 @@ Options:
     --database <name>   Name of the new database (required)
 
 Example:
-    llm-rules new --database myproject
-    llm-rules new --database react-frontend
+    ai-rules new --database myproject
+    ai-rules new --database react-frontend
 EOF
 }
 
 # Validate command usage
 usage_validate() {
     cat <<EOF
-Usage: llm-rules validate --manifest <path>
+Usage: ai-rules validate --manifest <path>
 
 Validate a manifest file and check for missing rule files.
 
@@ -107,7 +109,7 @@ Options:
     --manifest <path>   Path to manifest.ini file (required)
 
 Example:
-    llm-rules validate --manifest rules/myproject/manifest.ini
+    ai-rules validate --manifest rules/myproject/manifest
 EOF
 }
 
@@ -523,7 +525,7 @@ cmd_build() {
     output_dir=$(dirname "$output")
     if [ ! -d "$output_dir" ]; then
         echo "Error: Output directory does not exist: $output_dir" >&2
-        echo "Please create it first with: mkdir -p $output_dir" >&2
+        echo "Create it first with: mkdir -p $output_dir" >&2
         exit 1
     fi
 
@@ -587,12 +589,17 @@ cmd_build() {
 # Install command
 cmd_install() {
     local prefix=""
+    local bin_name="ai-rules"
 
     # Parse arguments
     while [ $# -gt 0 ]; do
         case "$1" in
             --prefix)
                 prefix="$2"
+                shift 2
+                ;;
+            --bin-name)
+                bin_name="$2"
                 shift 2
                 ;;
             --help|-h)
@@ -671,12 +678,12 @@ cmd_install() {
     # Check if directory exists
     if [ ! -d "$prefix" ]; then
         echo "Error: Directory '$prefix' does not exist"
-        echo "Please create it first or choose an existing directory"
+        echo "Create it first or choose an existing directory"
         exit 1
     fi
 
     # Create symlink
-    target="$prefix/llm-rules"
+    target="$prefix/$bin_name"
     if [ -e "$target" ]; then
         echo "Warning: $target already exists. Overwrite? (y/N)"
         read -r answer
@@ -686,24 +693,24 @@ cmd_install() {
         esac
     fi
 
-    ln -s "$SCRIPT_DIR/llm-rules" "$target"
-    echo "Successfully installed llm-rules to $target"
+    ln -s "$SCRIPT_DIR/ai-rules" "$target"
+    echo "Successfully installed $bin_name to $target"
 
     # Check if prefix is in PATH
     case ":$PATH:" in
         *":$prefix:"*)
-            echo "✓ $prefix is in your PATH - you can now use 'llm-rules' from anywhere"
+            echo "✓ $prefix is in your PATH - you can now use '$bin_name' from anywhere"
             ;;
         *)
             echo "⚠ $prefix is not in your PATH"
-            echo "To use 'llm-rules' from anywhere, add this to your shell config:"
+            echo "To use '$bin_name' from anywhere, add this to your shell config:"
             echo "  export PATH=\"\$PATH:$prefix\""
             ;;
     esac
 }
 
-# Deploy command
-cmd_deploy() {
+# Build-link command
+cmd_build_link() {
     local manifest=""
     local output=""
 
@@ -719,12 +726,12 @@ cmd_deploy() {
                 shift 2
                 ;;
             --help|-h)
-                usage_deploy
+                usage_build_link
                 exit 0
                 ;;
             *)
                 echo "Error: Unknown option $1" >&2
-                usage_deploy
+                usage_build_link
                 exit 1
                 ;;
         esac
@@ -733,13 +740,13 @@ cmd_deploy() {
     # Validate arguments
     if [ -z "$manifest" ]; then
         echo "Error: --manifest is required" >&2
-        usage_deploy
+        usage_build_link
         exit 1
     fi
 
     if [ -z "$output" ]; then
         echo "Error: --out is required" >&2
-        usage_deploy
+        usage_build_link
         exit 1
     fi
 
@@ -751,11 +758,12 @@ cmd_deploy() {
     # Build the documentation first
     cmd_build --manifest "$manifest" --out "$build_file"
 
-    # Create symlink to the built file
+    # Check if output directory exists
     output_dir=$(dirname "$output")
     if [ ! -d "$output_dir" ]; then
-        echo "Creating directory: $output_dir"
-        mkdir -p "$output_dir"
+        echo "Error: Output directory does not exist: $output_dir" >&2
+        echo "Create it first with: mkdir -p $output_dir" >&2
+        exit 1
     fi
 
     # Create or update symlink
@@ -812,16 +820,15 @@ cmd_new() {
     mkdir -p "$database_dir/rules"
 
     # Create manifest template
-    cat > "$database_dir/manifest.ini" <<EOF
+    cat > "$database_dir/manifest" <<EOF
 # $database Database Manifest
-# Add your rule files below
+# Add your rule files below using the pipe format
 
-[rules]
-# basic.md
-# advanced.md
+| basic
+# | advanced
 
 # Include rules from other databases:
-# other-database/specific-rule.md
+# | other-database/specific-rule
 EOF
 
     # Create example rule file
@@ -841,13 +848,13 @@ echo "Hello $database"
 EOF
 
     echo "✓ Created database structure at $database_dir"
-    echo "✓ Created manifest: $database_dir/manifest.ini"
+    echo "✓ Created manifest: $database_dir/manifest"
     echo "✓ Created example rule: $database_dir/rules/basic.md"
     echo ""
     echo "Next steps:"
-    echo "1. Edit $database_dir/manifest.ini to include your rules"
+    echo "1. Edit $database_dir/manifest to include your rules"
     echo "2. Add rule files to $database_dir/rules/"
-    echo "3. Build with: llm-rules build --manifest $database_dir/manifest.ini"
+    echo "3. Build with: ai-rules build --manifest $database_dir/manifest"
 }
 
 # Validate command
@@ -1018,9 +1025,9 @@ case "${1:-}" in
         shift
         cmd_install "$@"
         ;;
-    deploy)
+    build-link)
         shift
-        cmd_deploy "$@"
+        cmd_build_link "$@"
         ;;
     validate)
         shift

--- a/scripts/test
+++ b/scripts/test
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-# Test script for LLM Ruleset Manager
+# Test script for AI Ruleset Manager
 # Creates tmp directory, runs individual test scripts, then cleans up
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -17,7 +17,7 @@ TESTS_FAILED=0
 
 print_header() {
     echo "========================================"
-    echo "LLM Ruleset Manager - Test Suite"
+    echo "AI Ruleset Manager - Test Suite"
     echo "========================================"
     echo ""
 }

--- a/test/build-01-basic.sh
+++ b/test/build-01-basic.sh
@@ -18,7 +18,6 @@ fi
 # Create expected output based on basic fixture
 cat > test/tmp/build-01-expected.md <<'EOF'
 # Rule: rule1
-
 ## Rule One
 
 This is the first rule.
@@ -28,7 +27,6 @@ This is the first rule.
 Some basic content here.
 
 # Rule: rule2
-
 ## Rule Two
 
 This is the second rule.
@@ -38,7 +36,6 @@ This is the second rule.
 - Point one
 - Point two
 - Point three
-
 EOF
 
 # Compare actual vs expected

--- a/test/build-01-basic.sh
+++ b/test/build-01-basic.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 echo "Testing: Basic build functionality"
 
 # Test build with basic fixture (no code blocks)
-LLM_RULES_DIR=test/fixtures ./scripts/llm-rules build --manifest test/fixtures/basic/manifest --out test/tmp/build-01-basic.md
+LLM_RULES_DIR=test/fixtures ./scripts/ai-rules build --manifest test/fixtures/basic/manifest --out test/tmp/build-01-basic.md
 
 # Check that output file was created
 if [ ! -f "test/tmp/build-01-basic.md" ]; then

--- a/test/build-02-comments.sh
+++ b/test/build-02-comments.sh
@@ -18,7 +18,6 @@ fi
 # Create expected output - should be identical to basic build test since we're using same fixture
 cat > test/tmp/build-02-expected.md <<'EOF'
 # Rule: rule1
-
 ## Rule One
 
 This is the first rule.
@@ -28,7 +27,6 @@ This is the first rule.
 Some basic content here.
 
 # Rule: rule2
-
 ## Rule Two
 
 This is the second rule.
@@ -38,7 +36,6 @@ This is the second rule.
 - Point one
 - Point two
 - Point three
-
 EOF
 
 # Compare actual vs expected - this verifies that commented rules are properly ignored

--- a/test/build-02-comments.sh
+++ b/test/build-02-comments.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 echo "Testing: Comment handling"
 
 # Use basic fixture which has commented rule
-LLM_RULES_DIR=test/fixtures ./scripts/llm-rules build --manifest test/fixtures/basic/manifest --out test/tmp/build-02-comments.md
+LLM_RULES_DIR=test/fixtures ./scripts/ai-rules build --manifest test/fixtures/basic/manifest --out test/tmp/build-02-comments.md
 
 # Check that output file was created
 if [ ! -f "test/tmp/build-02-comments.md" ]; then

--- a/test/build-03-code-blocks.sh
+++ b/test/build-03-code-blocks.sh
@@ -18,7 +18,6 @@ fi
 # Create expected output - comments inside code blocks should be preserved
 cat > test/tmp/build-03-expected.md <<'EOF'
 # Rule: code-rule
-
 ## Code Rule
 
 This rule has code blocks with comments.
@@ -38,7 +37,6 @@ def hello():
 # Another comment
 echo "test"
 ```
-
 EOF
 
 # Compare actual vs expected

--- a/test/build-03-code-blocks.sh
+++ b/test/build-03-code-blocks.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 echo "Testing: Code block handling"
 
 # Test build with code blocks fixture
-LLM_RULES_DIR=test/fixtures ./scripts/llm-rules build --manifest test/fixtures/with_code_blocks/manifest --out test/tmp/build-03-code-blocks.md
+LLM_RULES_DIR=test/fixtures ./scripts/ai-rules build --manifest test/fixtures/with_code_blocks/manifest --out test/tmp/build-03-code-blocks.md
 
 # Check that output file was created
 if [ ! -f "test/tmp/build-03-code-blocks.md" ]; then

--- a/test/build-04-no-eof-newline.sh
+++ b/test/build-04-no-eof-newline.sh
@@ -18,7 +18,6 @@ fi
 # Create expected output - headings should be normalized and content preserved
 cat > test/tmp/build-04-expected.md <<'EOF'
 # Rule: no-newline-rule
-
 ## No Newline Rule
 
 This rule file does not end with a newline character.
@@ -26,7 +25,6 @@ This rule file does not end with a newline character.
 ### Content
 
 Some content here.
-
 EOF
 
 # Compare actual vs expected

--- a/test/build-04-no-eof-newline.sh
+++ b/test/build-04-no-eof-newline.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 echo "Testing: Files without EOF newline"
 
 # Test build with no_eof_newline fixture
-LLM_RULES_DIR=test/fixtures ./scripts/llm-rules build --manifest test/fixtures/no_eof_newline/manifest --out test/tmp/build-04-no-eof-newline.md
+LLM_RULES_DIR=test/fixtures ./scripts/ai-rules build --manifest test/fixtures/no_eof_newline/manifest --out test/tmp/build-04-no-eof-newline.md
 
 # Check that output file was created
 if [ ! -f "test/tmp/build-04-no-eof-newline.md" ]; then

--- a/test/build-05-nested.sh
+++ b/test/build-05-nested.sh
@@ -15,10 +15,9 @@ if [ ! -f "test/tmp/build-05-nested.md" ]; then
     exit 1
 fi
 
-# Create expected output - nested structure with rule titles
+# Create expected output based on nested fixture
 cat > test/tmp/build-05-expected.md <<'EOF'
 # Rule: parent
-
 ## Parent Rule
 
 This is the parent rule content.
@@ -28,7 +27,6 @@ This is the parent rule content.
 Some parent content here.
 
 ## Rule: child1
-
 ### First Child
 
 This is the first child rule.
@@ -38,7 +36,6 @@ This is the first child rule.
 Content for first child.
 
 ## Rule: child2
-
 ### Second Child
 
 This is the second child rule.
@@ -46,7 +43,6 @@ This is the second child rule.
 #### Another Section
 
 Content for second child.
-
 EOF
 
 # Compare actual vs expected

--- a/test/build-05-nested.sh
+++ b/test/build-05-nested.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 echo "Testing: Simple nested hierarchy"
 
 # Test build with nested fixture
-LLM_RULES_DIR=test/fixtures ./scripts/llm-rules build --manifest test/fixtures/nested/manifest --out test/tmp/build-05-nested.md
+LLM_RULES_DIR=test/fixtures ./scripts/ai-rules build --manifest test/fixtures/nested/manifest --out test/tmp/build-05-nested.md
 
 # Check that output file was created
 if [ ! -f "test/tmp/build-05-nested.md" ]; then

--- a/test/build-06-nested-complex.sh
+++ b/test/build-06-nested-complex.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 echo "Testing: Complex nested hierarchy"
 
 # Test build with complex nested fixture
-LLM_RULES_DIR=test/fixtures ./scripts/llm-rules build --manifest test/fixtures/nested_complex/manifest --out test/tmp/build-06-nested-complex.md
+LLM_RULES_DIR=test/fixtures ./scripts/ai-rules build --manifest test/fixtures/nested_complex/manifest --out test/tmp/build-06-nested-complex.md
 
 # Check that output file was created
 if [ ! -f "test/tmp/build-06-nested-complex.md" ]; then

--- a/test/build-06-nested-complex.sh
+++ b/test/build-06-nested-complex.sh
@@ -18,71 +18,59 @@ fi
 # Create expected output - complex nested structure with multiple levels
 cat > test/tmp/build-06-expected.md <<'EOF'
 # Rule: intro
-
 ## Introduction
 
 This is the introduction.
 
 # Rule: section1
-
 ## Section One
 
 Main content for section 1.
 
 ## Rule: section1-sub1
-
 ### Subsection 1.1
 
 Content for section 1, subsection 1.
 
 ## Rule: section1-sub2
-
 ### Subsection 1.2
 
 Content for section 1, subsection 2.
 
 ### Rule: section1-sub2-detail
-
 #### Detail 1.2.1
 
 Detailed content nested three levels deep.
 
 # Rule: section2
-
 ## Section Two
 
 Main content for section 2.
 
 ## Rule: section2-sub1
-
 ### Subsection 2.1
 
 Content for section 2, subsection 1.
 
 ### Rule: section2-sub1-detail1
-
 #### Detail 2.1.1
 
 First detail under subsection 2.1.
 
 ### Rule: section2-sub1-detail2
-
 #### Detail 2.1.2
 
 Second detail under subsection 2.1.
 
 ## Rule: section2-sub2
-
 ### Subsection 2.2
 
 Content for section 2, subsection 2.
 
 # Rule: conclusion
-
 ## Conclusion
 
 This is the conclusion.
-
 EOF
 
 # Compare actual vs expected

--- a/test/build-07-missing-manifest.sh
+++ b/test/build-07-missing-manifest.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 echo "Testing: Build with missing manifest file"
 
 # Test build with non-existent manifest file
-if LLM_RULES_DIR=test/fixtures ./scripts/llm-rules build --manifest test/fixtures/nonexistent/manifest --out test/tmp/build-07-missing-manifest.md 2>test/tmp/build-07-stderr.txt; then
+if LLM_RULES_DIR=test/fixtures ./scripts/ai-rules build --manifest test/fixtures/nonexistent/manifest --out test/tmp/build-07-missing-manifest.md 2>test/tmp/build-07-stderr.txt; then
     echo "FAIL: Build should have failed with missing manifest"
     exit 1
 fi

--- a/test/build-08-missing-rule-file.sh
+++ b/test/build-08-missing-rule-file.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 echo "Testing: Build with missing rule file"
 
 # Test build with manifest that references non-existent rule
-if LLM_RULES_DIR=test/fixtures ./scripts/llm-rules build --manifest test/fixtures/missing_rule/manifest --out test/tmp/build-08-missing-rule.md 2>test/tmp/build-08-stderr.txt; then
+if LLM_RULES_DIR=test/fixtures ./scripts/ai-rules build --manifest test/fixtures/missing_rule/manifest --out test/tmp/build-08-missing-rule.md 2>test/tmp/build-08-stderr.txt; then
     echo "FAIL: Build should have failed with missing rule file"
     exit 1
 fi

--- a/test/build-09-invalid-nesting.sh
+++ b/test/build-09-invalid-nesting.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 echo "Testing: Build with invalid nesting"
 
 # Test build with manifest that has invalid nesting
-if LLM_RULES_DIR=test/fixtures ./scripts/llm-rules build --manifest test/fixtures/invalid_nesting/manifest --out test/tmp/build-09-invalid-nesting.md 2>test/tmp/build-09-stderr.txt; then
+if LLM_RULES_DIR=test/fixtures ./scripts/ai-rules build --manifest test/fixtures/invalid_nesting/manifest --out test/tmp/build-09-invalid-nesting.md 2>test/tmp/build-09-stderr.txt; then
     echo "FAIL: Build should have failed with invalid nesting"
     exit 1
 fi

--- a/test/build-10-too-many-levels.sh
+++ b/test/build-10-too-many-levels.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 echo "Testing: Build with too many nesting levels"
 
 # Test build with manifest that has >6 nesting levels
-if LLM_RULES_DIR=test/fixtures ./scripts/llm-rules build --manifest test/fixtures/too_many_levels/manifest --out test/tmp/build-10-too-many-levels.md 2>test/tmp/build-10-stderr.txt; then
+if LLM_RULES_DIR=test/fixtures ./scripts/ai-rules build --manifest test/fixtures/too_many_levels/manifest --out test/tmp/build-10-too-many-levels.md 2>test/tmp/build-10-stderr.txt; then
     echo "FAIL: Build should have failed with too many nesting levels"
     exit 1
 fi

--- a/test/build-11-cross-database.sh
+++ b/test/build-11-cross-database.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Test cross-database inclusion functionality
+
+set -e
+cd "$(dirname "$0")/.."
+
+echo "Testing: Cross-database inclusion"
+
+# Test build with cross-database includes
+LLM_RULES_DIR=test/fixtures/cross_database ./scripts/ai-rules build --manifest test/fixtures/cross_database/main/manifest --out test/tmp/build-11-cross-database.md
+
+# Check that output file was created
+if [ ! -f "test/tmp/build-11-cross-database.md" ]; then
+    echo "FAIL: Output file not created"
+    exit 1
+fi
+
+# Create expected output
+cat > test/tmp/build-11-expected.md <<'EOF'
+# Rule: local-rule
+## Local Rule
+
+This is a rule local to the main database.
+
+# Rule: common-rule
+## Common Shared Rule
+
+This rule is shared across databases.
+
+## Rule: nested-shared
+### Nested Shared Rule
+
+This shared rule should appear as a nested item.
+
+# Rule: another-local
+## Another Local Rule
+
+Another rule in the main database.
+EOF
+
+# Compare actual vs expected
+if ! diff -q "test/tmp/build-11-cross-database.md" "test/tmp/build-11-expected.md" >/dev/null 2>&1; then
+    echo "FAIL: Cross-database inclusion output does not match expected"
+    echo "Expected:"
+    cat "test/tmp/build-11-expected.md"
+    echo ""
+    echo "Actual:"
+    cat "test/tmp/build-11-cross-database.md"
+    echo ""
+    echo "Diff:"
+    diff "test/tmp/build-11-expected.md" "test/tmp/build-11-cross-database.md" || true
+    exit 1
+fi
+
+echo "PASS: Cross-database inclusion"

--- a/test/build-12-nesting-warning.sh
+++ b/test/build-12-nesting-warning.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# Test auto-correction of invalid nesting with warning
+
+set -e
+cd "$(dirname "$0")/.."
+
+echo "Testing: Auto-correction of invalid nesting with warning"
+
+# Test build with invalid nesting - should auto-correct and emit warning
+LLM_RULES_DIR=test/fixtures ./scripts/ai-rules build --manifest test/fixtures/nesting_warning/manifest --out test/tmp/build-12-nesting-warning.md 2>test/tmp/build-12-stderr.txt
+
+# Check that output file was created (should succeed despite invalid nesting)
+if [ ! -f "test/tmp/build-12-nesting-warning.md" ]; then
+    echo "FAIL: Output file not created - build should have succeeded with auto-correction"
+    exit 1
+fi
+
+# Check that warning was emitted to stderr
+if ! grep -q "Warning: Invalid nesting" test/tmp/build-12-stderr.txt; then
+    echo "FAIL: Warning about invalid nesting not found in stderr"
+    echo "Stderr content:"
+    cat test/tmp/build-12-stderr.txt
+    exit 1
+fi
+
+if ! grep -q "Auto-correcting to level 2" test/tmp/build-12-stderr.txt; then
+    echo "FAIL: Auto-correction message not found in stderr"
+    echo "Stderr content:"
+    cat test/tmp/build-12-stderr.txt
+    exit 1
+fi
+
+# Create expected output (deeply-nested should be at level 2, not 3)
+cat > test/tmp/build-12-expected.md <<'EOF'
+# Rule: parent
+## Parent Rule
+
+This is a parent rule.
+
+## Rule: deeply-nested
+### Deeply Nested Rule
+
+This should be treated as level 2, not 3.
+
+# Rule: another-parent
+## Another Parent Rule
+
+Another parent rule.
+EOF
+
+# Compare actual vs expected
+if ! diff -q "test/tmp/build-12-nesting-warning.md" "test/tmp/build-12-expected.md" >/dev/null 2>&1; then
+    echo "FAIL: Auto-corrected output does not match expected"
+    echo "Expected:"
+    cat "test/tmp/build-12-expected.md"
+    echo ""
+    echo "Actual:"
+    cat "test/tmp/build-12-nesting-warning.md"
+    echo ""
+    echo "Diff:"
+    diff "test/tmp/build-12-expected.md" "test/tmp/build-12-nesting-warning.md" || true
+    exit 1
+fi
+
+echo "PASS: Auto-correction of invalid nesting with warning"

--- a/test/build-13-multiple-level-jumps.sh
+++ b/test/build-13-multiple-level-jumps.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+# Test auto-correction for multiple different level jumps
+
+set -e
+cd "$(dirname "$0")/.."
+
+echo "Testing: Auto-correction for multiple level jumps"
+
+# Test build with various level jumps - should auto-correct all and emit warnings
+LLM_RULES_DIR=test/fixtures ./scripts/ai-rules build --manifest test/fixtures/multiple_level_jumps/manifest --out test/tmp/build-13-multiple-jumps.md 2>test/tmp/build-13-stderr.txt
+
+# Check that output file was created
+if [ ! -f "test/tmp/build-13-multiple-jumps.md" ]; then
+    echo "FAIL: Output file not created"
+    exit 1
+fi
+
+# Count the number of warnings - should be 4
+warning_count=$(grep -c "Warning: Invalid nesting" test/tmp/build-13-stderr.txt || echo 0)
+if [ "$warning_count" -ne 4 ]; then
+    echo "FAIL: Expected 4 warnings, got $warning_count"
+    echo "Stderr content:"
+    cat test/tmp/build-13-stderr.txt
+    exit 1
+fi
+
+# Check specific auto-corrections
+if ! grep -q "Level 3 follows level 1" test/tmp/build-13-stderr.txt; then
+    echo "FAIL: Level 3→1 correction not found"
+    exit 1
+fi
+
+if ! grep -q "Level 4 follows level 2" test/tmp/build-13-stderr.txt; then
+    echo "FAIL: Level 4→2 correction not found"
+    exit 1
+fi
+
+if ! grep -q "Level 5 follows level 3" test/tmp/build-13-stderr.txt; then
+    echo "FAIL: Level 5→3 correction not found"
+    exit 1
+fi
+
+if ! grep -q "Level 5 follows level 1" test/tmp/build-13-stderr.txt; then
+    echo "FAIL: Level 5→1 correction not found"
+    exit 1
+fi
+
+# Create expected output with corrected nesting levels
+cat > test/tmp/build-13-expected.md <<'EOF'
+# Rule: level1
+## level1 Rule
+
+Test rule content.
+
+## Rule: jump-from-1-to-3
+### jump-from-1-to-3 Rule
+
+Test rule content.
+
+## Rule: level2
+### level2 Rule
+
+Test rule content.
+
+### Rule: jump-from-2-to-4
+#### jump-from-2-to-4 Rule
+
+Test rule content.
+
+### Rule: level3
+#### level3 Rule
+
+Test rule content.
+
+#### Rule: jump-from-3-to-5
+##### jump-from-3-to-5 Rule
+
+Test rule content.
+
+# Rule: back-to-1
+## back-to-1 Rule
+
+Test rule content.
+
+## Rule: big-jump-from-1-to-5
+### big-jump-from-1-to-5 Rule
+
+Test rule content.
+EOF
+
+# Compare actual vs expected
+if ! diff -q "test/tmp/build-13-multiple-jumps.md" "test/tmp/build-13-expected.md" >/dev/null 2>&1; then
+    echo "FAIL: Auto-corrected output does not match expected"
+    echo "Expected:"
+    cat "test/tmp/build-13-expected.md"
+    echo ""
+    echo "Actual:"
+    cat "test/tmp/build-13-multiple-jumps.md"
+    echo ""
+    echo "Diff:"
+    diff "test/tmp/build-13-expected.md" "test/tmp/build-13-multiple-jumps.md" || true
+    exit 1
+fi
+
+echo "PASS: Auto-correction for multiple level jumps"

--- a/test/build-14-auto-create-build-dir.sh
+++ b/test/build-14-auto-create-build-dir.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Test automatic creation of build/ directory when using default output
+
+set -e
+cd "$(dirname "$0")/.."
+
+echo "Testing: Automatic creation of build/ directory"
+
+# Remove build directory if it exists
+rm -rf build
+
+# Test build with default output (no --out flag) - should auto-create build/ directory
+LLM_RULES_DIR=test/fixtures ./scripts/ai-rules build --manifest test/fixtures/basic/manifest
+
+# Check that build directory was created
+if [ ! -d "build" ]; then
+    echo "FAIL: build/ directory was not created"
+    exit 1
+fi
+
+# Check that output file was created
+if [ ! -f "build/basic.md" ]; then
+    echo "FAIL: build/basic.md was not created"
+    exit 1
+fi
+
+# Test that custom directories still need to exist (should fail)
+rm -rf /tmp/test-nonexistent-dir
+if LLM_RULES_DIR=test/fixtures ./scripts/ai-rules build --manifest test/fixtures/basic/manifest --out /tmp/test-nonexistent-dir/custom.md 2>test/tmp/build-14-stderr.txt; then
+    echo "FAIL: Build should have failed with non-existent custom directory"
+    exit 1
+fi
+
+# Check that proper error message was displayed
+if ! grep -q "Output directory does not exist: /tmp/test-nonexistent-dir" test/tmp/build-14-stderr.txt; then
+    echo "FAIL: Expected error message not found"
+    echo "Stderr output:"
+    cat test/tmp/build-14-stderr.txt
+    exit 1
+fi
+
+# Test that custom directories work when they exist
+mkdir -p /tmp/test-custom-dir
+if ! LLM_RULES_DIR=test/fixtures ./scripts/ai-rules build --manifest test/fixtures/basic/manifest --out /tmp/test-custom-dir/custom.md; then
+    echo "FAIL: Build should have succeeded with existing custom directory"
+    exit 1
+fi
+
+# Check that custom output file was created
+if [ ! -f "/tmp/test-custom-dir/custom.md" ]; then
+    echo "FAIL: Custom output file was not created"
+    exit 1
+fi
+
+# Cleanup
+rm -rf /tmp/test-custom-dir
+
+echo "PASS: Automatic creation of build/ directory"

--- a/test/fixtures/cross_database/main/manifest
+++ b/test/fixtures/cross_database/main/manifest
@@ -1,0 +1,5 @@
+# Test manifest with cross-database includes
+| local-rule
+| shared/common-rule
+|| shared/nested-shared
+| another-local

--- a/test/fixtures/cross_database/main/rules/another-local.md
+++ b/test/fixtures/cross_database/main/rules/another-local.md
@@ -1,0 +1,3 @@
+# Another Local Rule
+
+Another rule in the main database.

--- a/test/fixtures/cross_database/main/rules/local-rule.md
+++ b/test/fixtures/cross_database/main/rules/local-rule.md
@@ -1,0 +1,3 @@
+# Local Rule
+
+This is a rule local to the main database.

--- a/test/fixtures/cross_database/shared/rules/common-rule.md
+++ b/test/fixtures/cross_database/shared/rules/common-rule.md
@@ -1,0 +1,3 @@
+# Common Shared Rule
+
+This rule is shared across databases.

--- a/test/fixtures/cross_database/shared/rules/nested-shared.md
+++ b/test/fixtures/cross_database/shared/rules/nested-shared.md
@@ -1,0 +1,3 @@
+# Nested Shared Rule
+
+This shared rule should appear as a nested item.

--- a/test/fixtures/multiple_level_jumps/manifest
+++ b/test/fixtures/multiple_level_jumps/manifest
@@ -1,0 +1,9 @@
+# Test various level jumps to verify auto-correction
+| level1
+||| jump-from-1-to-3
+|| level2
+|||| jump-from-2-to-4
+||| level3
+||||| jump-from-3-to-5
+| back-to-1
+||||| big-jump-from-1-to-5

--- a/test/fixtures/multiple_level_jumps/rules/back-to-1.md
+++ b/test/fixtures/multiple_level_jumps/rules/back-to-1.md
@@ -1,0 +1,3 @@
+# back-to-1 Rule
+
+Test rule content.

--- a/test/fixtures/multiple_level_jumps/rules/big-jump-from-1-to-5.md
+++ b/test/fixtures/multiple_level_jumps/rules/big-jump-from-1-to-5.md
@@ -1,0 +1,3 @@
+# big-jump-from-1-to-5 Rule
+
+Test rule content.

--- a/test/fixtures/multiple_level_jumps/rules/jump-from-1-to-3.md
+++ b/test/fixtures/multiple_level_jumps/rules/jump-from-1-to-3.md
@@ -1,0 +1,3 @@
+# jump-from-1-to-3 Rule
+
+Test rule content.

--- a/test/fixtures/multiple_level_jumps/rules/jump-from-2-to-4.md
+++ b/test/fixtures/multiple_level_jumps/rules/jump-from-2-to-4.md
@@ -1,0 +1,3 @@
+# jump-from-2-to-4 Rule
+
+Test rule content.

--- a/test/fixtures/multiple_level_jumps/rules/jump-from-3-to-5.md
+++ b/test/fixtures/multiple_level_jumps/rules/jump-from-3-to-5.md
@@ -1,0 +1,3 @@
+# jump-from-3-to-5 Rule
+
+Test rule content.

--- a/test/fixtures/multiple_level_jumps/rules/level1.md
+++ b/test/fixtures/multiple_level_jumps/rules/level1.md
@@ -1,0 +1,3 @@
+# level1 Rule
+
+Test rule content.

--- a/test/fixtures/multiple_level_jumps/rules/level2.md
+++ b/test/fixtures/multiple_level_jumps/rules/level2.md
@@ -1,0 +1,3 @@
+# level2 Rule
+
+Test rule content.

--- a/test/fixtures/multiple_level_jumps/rules/level3.md
+++ b/test/fixtures/multiple_level_jumps/rules/level3.md
@@ -1,0 +1,3 @@
+# level3 Rule
+
+Test rule content.

--- a/test/fixtures/nesting_warning/manifest
+++ b/test/fixtures/nesting_warning/manifest
@@ -1,0 +1,4 @@
+# Test manifest with invalid nesting that should auto-correct
+| parent
+||| deeply-nested
+| another-parent

--- a/test/fixtures/nesting_warning/rules/another-parent.md
+++ b/test/fixtures/nesting_warning/rules/another-parent.md
@@ -1,0 +1,3 @@
+# Another Parent Rule
+
+Another parent rule.

--- a/test/fixtures/nesting_warning/rules/deeply-nested.md
+++ b/test/fixtures/nesting_warning/rules/deeply-nested.md
@@ -1,0 +1,3 @@
+# Deeply Nested Rule
+
+This should be treated as level 2, not 3.

--- a/test/fixtures/nesting_warning/rules/parent.md
+++ b/test/fixtures/nesting_warning/rules/parent.md
@@ -1,0 +1,3 @@
+# Parent Rule
+
+This is a parent rule.

--- a/test/new-01-basic.sh
+++ b/test/new-01-basic.sh
@@ -44,7 +44,6 @@ fi
 
 # Verify manifest content
 cat > test/tmp/new-01-expected-manifest <<'EOF'
-# testdb Database Manifest
 # Add your rule files below using the pipe format
 
 | basic

--- a/test/new-01-basic.sh
+++ b/test/new-01-basic.sh
@@ -7,19 +7,19 @@ cd "$(dirname "$0")/.."
 echo "Testing: New command"
 
 # Test creating new database - capture output
-LLM_RULES_DIR=test/tmp ./scripts/llm-rules new --database testdb > test/tmp/new-01-output.txt
+LLM_RULES_DIR=test/tmp ./scripts/ai-rules new --database testdb > test/tmp/new-01-output.txt
 
 # Create expected output for new command
 cat > test/tmp/new-01-expected.txt <<'EOF'
 Creating new database: testdb
 ✓ Created database structure at test/tmp/testdb
-✓ Created manifest: test/tmp/testdb/manifest.ini
+✓ Created manifest: test/tmp/testdb/manifest
 ✓ Created example rule: test/tmp/testdb/rules/basic.md
 
 Next steps:
-1. Edit test/tmp/testdb/manifest.ini to include your rules
+1. Edit test/tmp/testdb/manifest to include your rules
 2. Add rule files to test/tmp/testdb/rules/
-3. Build with: llm-rules build --manifest test/tmp/testdb/manifest.ini
+3. Build with: ai-rules build --manifest test/tmp/testdb/manifest
 EOF
 
 # Compare actual vs expected
@@ -37,31 +37,30 @@ if ! diff -q "test/tmp/new-01-output.txt" "test/tmp/new-01-expected.txt" >/dev/n
 fi
 
 # Check that files were actually created
-if [ ! -d "test/tmp/testdb" ] || [ ! -f "test/tmp/testdb/manifest.ini" ] || [ ! -f "test/tmp/testdb/rules/basic.md" ]; then
+if [ ! -d "test/tmp/testdb" ] || [ ! -f "test/tmp/testdb/manifest" ] || [ ! -f "test/tmp/testdb/rules/basic.md" ]; then
     echo "FAIL: Required files/directories not created"
     exit 1
 fi
 
 # Verify manifest content
-cat > test/tmp/new-01-expected-manifest.ini <<'EOF'
+cat > test/tmp/new-01-expected-manifest <<'EOF'
 # testdb Database Manifest
-# Add your rule files below
+# Add your rule files below using the pipe format
 
-[rules]
-# basic.md
-# advanced.md
+| basic
+# | advanced
 
 # Include rules from other databases:
-# other-database/specific-rule.md
+# | other-database/specific-rule
 EOF
 
-if ! diff -q "test/tmp/testdb/manifest.ini" "test/tmp/new-01-expected-manifest.ini" >/dev/null 2>&1; then
+if ! diff -q "test/tmp/testdb/manifest" "test/tmp/new-01-expected-manifest" >/dev/null 2>&1; then
     echo "FAIL: Generated manifest does not match expected"
     exit 1
 fi
 
 # Test that creating existing database fails with specific error
-LLM_RULES_DIR=test/tmp ./scripts/llm-rules new --database testdb > test/tmp/new-01-error.txt 2>&1 || true
+LLM_RULES_DIR=test/tmp ./scripts/ai-rules new --database testdb > test/tmp/new-01-error.txt 2>&1 || true
 
 # Create expected error output
 cat > test/tmp/new-01-expected-error.txt <<'EOF'

--- a/test/new-02-missing-database.sh
+++ b/test/new-02-missing-database.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 echo "Testing: New command with missing database argument"
 
 # Test new command without --database argument
-if LLM_RULES_DIR=test/tmp ./scripts/llm-rules new 2>test/tmp/new-02-stderr.txt; then
+if LLM_RULES_DIR=test/tmp ./scripts/ai-rules new 2>test/tmp/new-02-stderr.txt; then
     echo "FAIL: New command should have failed without --database"
     exit 1
 fi

--- a/test/new-03-database-exists.sh
+++ b/test/new-03-database-exists.sh
@@ -10,7 +10,7 @@ echo "Testing: New command when database already exists"
 mkdir -p test/tmp/existing-db
 
 # Test new command with existing database
-if LLM_RULES_DIR=test/tmp ./scripts/llm-rules new --database existing-db 2>test/tmp/new-03-stderr.txt; then
+if LLM_RULES_DIR=test/tmp ./scripts/ai-rules new --database existing-db 2>test/tmp/new-03-stderr.txt; then
     echo "FAIL: New command should have failed with existing database"
     exit 1
 fi

--- a/test/validate-01-basic.sh
+++ b/test/validate-01-basic.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 echo "Testing: Validate command"
 
 # Test validate on existing basic fixture (should pass) - capture output
-LLM_RULES_DIR=test/fixtures ./scripts/llm-rules validate --manifest test/fixtures/basic/manifest > test/tmp/validate-01-output.txt
+LLM_RULES_DIR=test/fixtures ./scripts/ai-rules validate --manifest test/fixtures/basic/manifest > test/tmp/validate-01-output.txt
 
 # Create expected output for successful validation
 cat > test/tmp/validate-01-expected.txt <<'EOF'
@@ -40,7 +40,7 @@ if ! diff -q "test/tmp/validate-01-output.txt" "test/tmp/validate-01-expected.tx
 fi
 
 # Test validate with non-existent manifest (should fail with specific error)
-LLM_RULES_DIR=test/fixtures ./scripts/llm-rules validate --manifest test/fixtures/nonexistent/manifest > test/tmp/validate-01-error.txt 2>&1 || true
+LLM_RULES_DIR=test/fixtures ./scripts/ai-rules validate --manifest test/fixtures/nonexistent/manifest > test/tmp/validate-01-error.txt 2>&1 || true
 
 # Create expected error output
 cat > test/tmp/validate-01-expected-error.txt <<'EOF'

--- a/test/validate-02-missing-manifest.sh
+++ b/test/validate-02-missing-manifest.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 echo "Testing: Validate with missing manifest file"
 
 # Test validate with non-existent manifest file
-if LLM_RULES_DIR=test/fixtures ./scripts/llm-rules validate --manifest test/fixtures/nonexistent/manifest 2>test/tmp/validate-02-stderr.txt; then
+if LLM_RULES_DIR=test/fixtures ./scripts/ai-rules validate --manifest test/fixtures/nonexistent/manifest 2>test/tmp/validate-02-stderr.txt; then
     echo "FAIL: Validate should have failed with missing manifest"
     exit 1
 fi

--- a/test/validate-03-missing-rule-file.sh
+++ b/test/validate-03-missing-rule-file.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 echo "Testing: Validate with missing rule file"
 
 # Test validate with manifest that references non-existent rule
-if LLM_RULES_DIR=test/fixtures ./scripts/llm-rules validate --manifest test/fixtures/missing_rule/manifest >test/tmp/validate-03-output.txt 2>&1; then
+if LLM_RULES_DIR=test/fixtures ./scripts/ai-rules validate --manifest test/fixtures/missing_rule/manifest >test/tmp/validate-03-output.txt 2>&1; then
     echo "FAIL: Validate should have failed with missing rule file"
     exit 1
 fi

--- a/test/validate-04-invalid-nesting.sh
+++ b/test/validate-04-invalid-nesting.sh
@@ -1,20 +1,22 @@
 #!/bin/sh
-# Test validate command with invalid nesting
+# Test validate command with invalid nesting warning
 
 set -e
 cd "$(dirname "$0")/.."
 
-echo "Testing: Validate with invalid nesting"
+echo "Testing: Validate with invalid nesting warning"
 
-# Test validate with manifest that has invalid nesting
-if LLM_RULES_DIR=test/fixtures ./scripts/ai-rules validate --manifest test/fixtures/invalid_nesting/manifest >test/tmp/validate-04-output.txt 2>&1; then
-    echo "FAIL: Validate should have failed with invalid nesting"
+# Test validate with manifest that has invalid nesting - should succeed with warning
+if ! LLM_RULES_DIR=test/fixtures ./scripts/ai-rules validate --manifest test/fixtures/invalid_nesting/manifest >test/tmp/validate-04-output.txt 2>&1; then
+    echo "FAIL: Validate should have succeeded with warning"
+    echo "Output:"
+    cat test/tmp/validate-04-output.txt
     exit 1
 fi
 
-# Check that invalid nesting was detected
-if ! grep -q "Invalid nesting" test/tmp/validate-04-output.txt; then
-    echo "FAIL: Expected invalid nesting message not found"
+# Check that nesting warning was displayed
+if ! grep -q "Nesting warning" test/tmp/validate-04-output.txt; then
+    echo "FAIL: Expected nesting warning message not found"
     echo "Output:"
     cat test/tmp/validate-04-output.txt
     exit 1
@@ -28,12 +30,20 @@ if ! grep -q "level 3 follows level 1" test/tmp/validate-04-output.txt; then
     exit 1
 fi
 
-# Check that validation failed
-if ! grep -q "has.*missing rule(s)" test/tmp/validate-04-output.txt; then
-    echo "FAIL: Validation failure message not found"
+# Check that auto-correction is mentioned
+if ! grep -q "will auto-correct to" test/tmp/validate-04-output.txt; then
+    echo "FAIL: Auto-correction message not found"
     echo "Output:"
     cat test/tmp/validate-04-output.txt
     exit 1
 fi
 
-echo "PASS: Validate correctly fails with invalid nesting"
+# Check that validation succeeded
+if ! grep -q "is valid!" test/tmp/validate-04-output.txt; then
+    echo "FAIL: Validation success message not found"
+    echo "Output:"
+    cat test/tmp/validate-04-output.txt
+    exit 1
+fi
+
+echo "PASS: Validate correctly shows warning for invalid nesting"

--- a/test/validate-04-invalid-nesting.sh
+++ b/test/validate-04-invalid-nesting.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 echo "Testing: Validate with invalid nesting"
 
 # Test validate with manifest that has invalid nesting
-if LLM_RULES_DIR=test/fixtures ./scripts/llm-rules validate --manifest test/fixtures/invalid_nesting/manifest >test/tmp/validate-04-output.txt 2>&1; then
+if LLM_RULES_DIR=test/fixtures ./scripts/ai-rules validate --manifest test/fixtures/invalid_nesting/manifest >test/tmp/validate-04-output.txt 2>&1; then
     echo "FAIL: Validate should have failed with invalid nesting"
     exit 1
 fi


### PR DESCRIPTION
- `llm-rules` rename to `ai-rules` throughout codebase
- Rename `deploy` command, now it's `build-link`.
- Reference rules from other databases using `shared/rule-name` format
- Level jumps like `|` to `|||` automatically fix with warnings instead of failing
- Single newlines between rules, trimmed leading/trailing whitespace
- Better tests